### PR TITLE
クエリ走りすぎる問題とuser削除時のエラー対応

### DIFF
--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -4,7 +4,7 @@ class ProgramsController < ApplicationController
   before_action :authorized_user, only: %i[ edit update destroy ]
 
   def index
-    @programs = Program.all
+    @programs = Program.includes(:user).all
   end
 
   def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -42,10 +42,10 @@ class UsersController < ApplicationController
   end
 
   def destroy
+    programs = @user.programs
     @user.destroy!
     flash[:success] = "User was successfully destroyed."
     redirect_to users_path, status: :see_other
-    head :no_content
   end
 
   private

--- a/app/models/letterbox.rb
+++ b/app/models/letterbox.rb
@@ -3,7 +3,7 @@ class Letterbox < ApplicationRecord
   validates :body, allow_nil: true, length: { maximum: 255 }
 
   belongs_to :program
-  has_many :letters
+  has_many :letters, dependent: :nullify
 
   def self.ransackable_attributes(auth_object = nil)
     [ "id" ]

--- a/app/models/program.rb
+++ b/app/models/program.rb
@@ -8,7 +8,7 @@ class Program < ApplicationRecord
   has_many :user_participations, dependent: :destroy
   has_many :participants, through: :user_participations, source: :user
   has_many :letterboxes, dependent: :destroy
-  has_many :letters
+  has_many :letters, dependent: :nullify
 
   def self.ransackable_associations(auth_object = nil)
     [ "letter", "letterbox" ]

--- a/app/views/letterboxes/_letterbox.html.erb
+++ b/app/views/letterboxes/_letterbox.html.erb
@@ -29,7 +29,7 @@
           <i class="bi bi-arrow-right ms-2 transition-icon"></i>
         <% end %>
       </div>
-      <% if (producer?(current_user, letterbox.program) || current_user&.admin) %>
+      <% if (producer?(current_user, letterbox.program) || current_user&.admin?) %>
         <%= link_to edit_program_letterbox_path(letterbox.program, letterbox), 
             class: "btn btn-outline-light hover-lift" do %>
           <i class="bi bi-pencil me-2"></i>

--- a/app/views/programs/_program.html.erb
+++ b/app/views/programs/_program.html.erb
@@ -18,7 +18,7 @@
       <div class="program-meta mb-3">
         <% if producer?(current_user, program) || current_user&.admin? %>
           <%= link_to new_program_invitation_path(program), 
-              class: "btn btn-outline-light btn-sm rounded-pill hover-lift" do %>
+              class: "btn btn-outline-light btn-sm rounded-pill hover-lift mb-3" do %>
             <i class="bi bi-person-plus me-2"></i>
             ユーザーを招待する
           <% end %>

--- a/app/views/programs/index.html.erb
+++ b/app/views/programs/index.html.erb
@@ -18,8 +18,11 @@
       <% end %>
     </div>
 
-    <div class="row g-4" id="programs">
-      <%= render @programs %>
+    <div class="row g-4">
+      <%= render partial: "programs/program", 
+                collection: @programs, 
+                as: :program,
+                locals: { current_user: current_user } %>
     </div>
   </div>
 </div>

--- a/app/views/programs/show.html.erb
+++ b/app/views/programs/show.html.erb
@@ -43,8 +43,11 @@
     </div>
 
     <div class="row g-4">
-      <%= render @program.letterboxes %>
-    </div>
+        <%= render partial: "letterboxes/letterbox", 
+              collection: @program.letterboxes, 
+              as: :letterbox,
+              locals: { current_user: current_user } %>
+      </div>
   </div>
 
   <div class="glass-morphism p-4 mb-5">

--- a/app/views/static_page/top.html.erb
+++ b/app/views/static_page/top.html.erb
@@ -40,9 +40,12 @@
           最近追加されたお便り箱
         </h2>
       </div>
-      
-      <div class="row g-4" id="letterboxes">
-        <%= render @letterboxes %>
+
+      <div class="row g-4">
+        <%= render partial: "letterboxes/letterbox", 
+              collection: @letterboxes, 
+              as: :letterbox,
+              locals: { current_user: current_user } %>
       </div>
     </section>
   <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -24,9 +24,10 @@
       </h3>
 
       <div class="row g-4">
-        <% @programs.each do |program| %>
-          <%= render program %>
-        <% end %>
+        <%= render partial: "programs/program", 
+              collection: @programs, 
+              as: :program,
+              locals: { current_user: current_user } %>
       </div>
     </div>
 


### PR DESCRIPTION
# 概要
- programやletterboxのパーシャルで表示されるものをcurrent_userの属性によって出し分けする際に毎度current_userが呼び出されてクエリがめっちゃ走るのでその対策

- user削除時にそのuserが持っていたprogramに関連づいたletterのprogram_idやletterbox_idにnullになってエラーになるので削除時のみnullを許可するように
