### PR TITLE
remeberme機能のエラー解消

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,8 +4,6 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable
 
-  attr_accessor :remember_token
-
   validates :email, uniqueness: true, allow_blank: true # deviceとともに追加
 
   validates :name,  presence: true, uniqueness: true, length: { maximum: 50 }
@@ -25,25 +23,6 @@ class User < ApplicationRecord
   # ランダムなトークンを返す
   def self.new_token
     SecureRandom.urlsafe_base64
-  end
-
-  def remember
-    self.remember_token = User.new_token
-    update_attribute(:remember_digest, User.digest(remember_token))
-    remember_digest
-  end
-
-  def authenticated?(remember_token)
-    return false if remember_digest.nil?
-    BCrypt::Password.new(remember_digest).is_password?(remember_token)
-  end
-
-  def forget
-    update_attribute(:remember_digest, nil)
-  end
-
-  def session_token
-    remember_digest || remember
   end
 
   # ransack用


### PR DESCRIPTION
# 概要
remember_me機能のエラー解消

## 内容
[![Image from Gyazo](https://i.gyazo.com/cc71f3bc87c8fef46fa454059e07a7fc.png)](https://gyazo.com/cc71f3bc87c8fef46fa454059e07a7fc)
こんな感じでhas_secure_passwordで作ってたremember_me機能の残骸が残ってたので↓みたいな感じで全部削除した
[![Image from Gyazo](https://i.gyazo.com/97700b4aca9e17d1cd41584c6bd25446.png)](https://gyazo.com/97700b4aca9e17d1cd41584c6bd25446)