### PR TITLE
letter投稿でmarkdownを使えるように改修

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,19 +42,27 @@ gem "thruster", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+# 検索機能
 gem "ransack", "4.2.1"
 
+# svgの表示
 gem "inline_svg"
 
+# ページネーション
 gem "kaminari"
-
 gem "bootstrap5-kaminari-views"
 
+# meta tag設定用　主にtwitter共有用
 gem "meta-tags"
 
+# 認証機能
 gem "devise", "~> 4.9", ">= 4.9.4"
-
+# debviseのi18n対応
 gem "devise-i18n-views"
+
+# マークダウン用
+gem "redcarpet"
+gem 'rouge'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -272,6 +272,7 @@ GEM
       i18n
     rdoc (6.7.0)
       psych (>= 4.0.0)
+    redcarpet (3.6.0)
     regexp_parser (2.9.2)
     reline (0.5.11)
       io-console (~> 0.5)
@@ -279,6 +280,7 @@ GEM
       actionpack (>= 5.2)
       railties (>= 5.2)
     rexml (3.3.9)
+    rouge (4.5.1)
     rubocop (1.68.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -392,6 +394,8 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (= 7.2.1)
   ransack (= 4.2.1)
+  redcarpet
+  rouge
   rubocop-rails-omakase
   selenium-webdriver
   solid_cable

--- a/app/assets/stylesheets/_rouge.scss
+++ b/app/assets/stylesheets/_rouge.scss
@@ -1,0 +1,203 @@
+.highlight table td { padding: 5px; }
+.highlight table pre { margin: 0; }
+.highlight .gh {
+  color: #999999;
+}
+.highlight .sr {
+  color: #f6aa11;
+}
+.highlight .go {
+  color: #888888;
+}
+.highlight .gp {
+  color: #555555;
+}
+.highlight .ge {
+  font-style: italic;
+}
+.highlight .ges {
+  font-weight: bold;
+  font-style: italic;
+}
+.highlight .gs {
+  font-weight: bold;
+}
+.highlight .gu {
+  color: #aaaaaa;
+}
+.highlight .nb {
+  color: #f6aa11;
+}
+.highlight .cm {
+  color: #75715e;
+}
+.highlight .cp {
+  color: #75715e;
+}
+.highlight .c1 {
+  color: #75715e;
+}
+.highlight .cs {
+  color: #75715e;
+}
+.highlight .c, .highlight .ch, .highlight .cd, .highlight .cpf {
+  color: #75715e;
+}
+.highlight .err {
+  color: #960050;
+}
+.highlight .gr {
+  color: #960050;
+}
+.highlight .gt {
+  color: #960050;
+}
+.highlight .gd {
+  color: #49483e;
+}
+.highlight .gi {
+  color: #49483e;
+}
+.highlight .kc {
+  color: #66d9ef;
+}
+.highlight .kd {
+  color: #66d9ef;
+}
+.highlight .kr {
+  color: #66d9ef;
+}
+.highlight .no {
+  color: #66d9ef;
+}
+.highlight .kt {
+  color: #66d9ef;
+}
+.highlight .mf {
+  color: #ae81ff;
+}
+.highlight .mh {
+  color: #ae81ff;
+}
+.highlight .il {
+  color: #ae81ff;
+}
+.highlight .mi {
+  color: #ae81ff;
+}
+.highlight .mo {
+  color: #ae81ff;
+}
+.highlight .m, .highlight .mb, .highlight .mx {
+  color: #ae81ff;
+}
+.highlight .sc {
+  color: #ae81ff;
+}
+.highlight .se {
+  color: #ae81ff;
+}
+.highlight .ss {
+  color: #ae81ff;
+}
+.highlight .sd {
+  color: #e6db74;
+}
+.highlight .s2 {
+  color: #e6db74;
+}
+.highlight .sb {
+  color: #e6db74;
+}
+.highlight .sh {
+  color: #e6db74;
+}
+.highlight .si {
+  color: #e6db74;
+}
+.highlight .sx {
+  color: #e6db74;
+}
+.highlight .s1 {
+  color: #e6db74;
+}
+.highlight .s, .highlight .sa, .highlight .dl {
+  color: #e6db74;
+}
+.highlight .na {
+  color: #a6e22e;
+}
+.highlight .nc {
+  color: #a6e22e;
+}
+.highlight .nd {
+  color: #a6e22e;
+}
+.highlight .ne {
+  color: #a6e22e;
+}
+.highlight .nf, .highlight .fm {
+  color: #a6e22e;
+}
+.highlight .vc {
+  color: #ffffff;
+  background-color: #272822;
+}
+.highlight .nn {
+  color: #ffffff;
+  background-color: #272822;
+}
+.highlight .nl {
+  color: #ffffff;
+  background-color: #272822;
+}
+.highlight .ni {
+  color: #ffffff;
+  background-color: #272822;
+}
+.highlight .bp {
+  color: #ffffff;
+  background-color: #272822;
+}
+.highlight .vg {
+  color: #ffffff;
+  background-color: #272822;
+}
+.highlight .vi {
+  color: #ffffff;
+  background-color: #272822;
+}
+.highlight .nv, .highlight .vm {
+  color: #ffffff;
+  background-color: #272822;
+}
+.highlight .w {
+  color: #ffffff;
+  background-color: #272822;
+}
+.highlight {
+  color: #ffffff;
+  background-color: #272822;
+}
+.highlight .n, .highlight .py, .highlight .nx {
+  color: #ffffff;
+  background-color: #272822;
+}
+.highlight .ow {
+  color: #f92672;
+}
+.highlight .nt {
+  color: #f92672;
+}
+.highlight .k, .highlight .kv {
+  color: #f92672;
+}
+.highlight .kn {
+  color: #f92672;
+}
+.highlight .kp {
+  color: #f92672;
+}
+.highlight .o {
+  color: #f92672;
+}

--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -1,5 +1,6 @@
 @import 'bootstrap/scss/bootstrap';
 @import 'bootstrap-icons/font/bootstrap-icons';
+@import 'rouge';
 
 // 変数定義
 $primary-gradient: linear-gradient(120deg, #7aa2f7, #bb9af7);

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require 'rouge/plugins/redcarpet'
+require 'redcarpet'
+require 'redcarpet/render_strip'
+
+class CustomRenderHTML < Redcarpet::Render::HTML
+  include Rouge::Plugins::Redcarpet
+
+  # Rouge::Plugins::Redcarpetのメソッドを上書きする
+  def block_code(code, language)
+    # もしコードブロックに言語とファイル名が定義されたら取得する。例： ```ruby:test.rb
+    filename = ''
+    if language.present?
+      filename = language.split(':')[1]
+      language = language.split(':')[0].downcase
+    else
+      language = "code"
+    end
+
+    lexer = Rouge::Lexer.find_fancy(language, code) || Rouge::Lexers::PlainText
+    code.gsub!(/^    /, "\t") if lexer.tag == 'make'
+    formatter = rouge_formatter(lexer)
+    result = formatter.format(lexer.lex(code))
+    return "<div class=#{wrap_class}>#{copy_button}#{result}</div" if filename.blank? && language.blank?
+
+    compose_filename_and_language(result, filename, language)
+  end
+
+  def rouge_formatter(_options = {})
+    options = {
+      css_class: 'highlight',
+      line_numbers: true,
+      line_format: '<span>%i</span>'
+    }
+    Rouge::Formatters::HTMLLegacy.new(options)
+  end
+
+  private
+
+  # wrap CSSクラス名の定義
+  def wrap_class
+    'highlight-wrap'
+  end
+
+  # コピーボタンの定義。クリックするとJavaScriptファンクションが実行される
+  def copy_button
+    "<button onclick='copy(this)'>Copy</button>"
+  end
+
+  # コードブロックの言語、ファイル名、コピーボタンを設置する
+  def compose_filename_and_language(result, filename, language)
+    info_section = [filename, language].select(&:present?).map.with_index do |text, i|
+      i.zero? ? "<span class='highlight-info'>#{text}</span>" : nil
+    end.compact.join
+
+    %(<div class=#{wrap_class}>
+        #{copy_button}
+        #{info_section}
+        #{result}
+      </div>
+    )
+  end
+end
+
+module MarkdownHelper
+  def plaintext(text)
+    markdown = Redcarpet::Markdown.new(Redcarpet::Render::StripDown)
+    markdown.render(text)
+  end
+
+  def markdown(text)
+    options = {
+      with_toc_data: true,
+      hard_wrap: true,
+      escape_html: true,
+      filter_html: true,
+      safe_links_only: true,
+    }
+    extensions = {
+      no_intra_emphasis: true,
+      tables: true,
+      fenced_code_blocks: true,
+      autolink: true,
+      lax_spacing: true,
+      lax_html_blocks: true,
+      footnotes: true,
+      space_after_headers: true,
+      strikethrough: true,
+      underline: true,
+      highlight: true,
+      quote: true
+    }
+
+    renderer = CustomRenderHTML.new(options)
+    markdown = Redcarpet::Markdown.new(renderer, extensions)
+    markdown.render(text).html_safe
+  end
+
+  def toc(text)
+    renderer = Redcarpet::Render::HTML_TOC.new(nesting_level: 6)
+    markdown = Redcarpet::Markdown.new(renderer)
+    markdown.render(text).html_safe
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,5 +28,18 @@
     </div>
     <%= render 'shared/header' %>
     <%= yield %>
+    <script>
+      window.copy = function(e) {
+        // クリックしたボタンに紐づくコードの範囲の定義
+        let code = e.closest('.highlight-wrap').querySelector('.rouge-code')
+
+        // クリップボードにコードをコピーしてから、ボタンのテキストを変更する
+        navigator.clipboard.writeText(code.innerText)
+          .then(() => e.innerText = 'Copied')
+
+        // 任意：コピーしたコードが選択されたようにする
+        window.getSelection().selectAllChildren(code)
+      }
+    </script>
   </body>
 </html>

--- a/app/views/letterboxes/_letterbox.html.erb
+++ b/app/views/letterboxes/_letterbox.html.erb
@@ -31,7 +31,7 @@
       <%# アクションボタン %>
       <div class="card-actions">
         <% unless action_name == "index" %>
-          <%= link_to program_path(letterbox.program, letter: {letterbox_id: letterbox.id}), 
+          <%= link_to program_path(letterbox.program, letter: {letterbox_id: letterbox.id}, anchor: "letterForm"), 
               class: "btn btn-primary rounded-pill px-4 py-2 d-inline-flex align-items-center",
               data: { turbo: false }  do %>
             <i class="bi bi-pencil-square me-2"></i>

--- a/app/views/letterboxes/index.html.erb
+++ b/app/views/letterboxes/index.html.erb
@@ -11,7 +11,7 @@
     </div>
 
     <div class="search-form-container">
-      <%= search_form_for @q, url: program_letters_path(@program), 
+      <%= search_form_for @q, url: program_letterboxes_path(@program), 
           class: "search-form" do |f| %>
         
         <!-- メイン検索エリア -->

--- a/app/views/letters/_form.html.erb
+++ b/app/views/letters/_form.html.erb
@@ -1,4 +1,4 @@
-<div class="glass-morphism p-4">
+<div class="glass-morphism p-4" id="letterForm">
   <%= form_with(model: letter, url: letter_action_path(letter, program), class: "needs-validation") do |form| %>
     <% if letter.errors.any? %>
       <div class="alert alert-danger">

--- a/app/views/letters/_letter.html.erb
+++ b/app/views/letters/_letter.html.erb
@@ -6,7 +6,7 @@
     </div>
     
     <div class="letter-body p-3 rounded">
-      <p class="mb-0 card-text"><%= simple_format(letter.body) %></p>
+      <p class="mb-0 card-text"><%= markdown(letter.body) %></p>
     </div>
 
     <% if action_name == "show" %>

--- a/config/initializers/rouge_theme.rb
+++ b/config/initializers/rouge_theme.rb
@@ -1,0 +1,9 @@
+# config/initializers/rouge_theme.rb
+require 'rouge'
+require 'fileutils'
+
+rouge_theme = Rouge::Themes::MonokaiSublime.render(scope: '.highlight')
+
+# stylesheets ディレクトリにRougeのスタイルシートを作成
+FileUtils.mkdir_p(Rails.root.join('app', 'assets', 'stylesheets'))
+File.write(Rails.root.join('app', 'assets', 'stylesheets', '_rouge.scss'), rouge_theme)


### PR DESCRIPTION
# 概要
- letter投稿でマークダウンが表示できるように改修
- letterboxのお便りを書くボタン（リンク）を押すと番組詳細の「お便り投稿フォーム」の位置にリンクするように変更
- ついでにletterboxの検索後letterの検索結果が表示されてしまうバグ修正

## 内容
- gem "redcarpet"を導入しマークダウンを解析、表示できるようにapp/helpers/markdown_helper.rbにredcarpet用の設定を記述
- gem 'rouge'でマークダウンで記述したコードブロックに対してシンタックスハイライトが適用されるように設定
- gem 'rouge'の設定に必要な_rouge.scss.erbをうまく読み込めなかったのでconfig/initializers/rouge_theme.rbにこのgemのSCSSを読み込んで名前を付けてSCSSファイルとして保存しそのSCSSファイルをapp/assets/stylesheets/application.bootstrap.scssにimport

- letterboxのお便りを書くボタン（リンク）を押すと番組詳細の「お便り投稿フォーム」の位置にリンクするように変更するためにapp/views/letters/_form.html.erbにidを追加
- app/views/letterboxes/_letterbox.html.erbの「お便りを書く」リンクにanchor追加