### PR TITLE
お便りランダム表示ウィンドウの表示バグ修正

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -15,7 +15,6 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
     resource.skip_confirmation! # 確認をスキップ
 
-
     if resource.save
       # ユーザーが保存された場合の処理
       sign_in(resource)  # サインインさせる

--- a/app/views/letters/index.html.erb
+++ b/app/views/letters/index.html.erb
@@ -83,7 +83,7 @@
 
         <%= link_to program_random_letters_path(q: permitted_q_params),
             class: "btn btn-primary rounded-pill px-4 hover-lift",
-            onclick: "window.open(this.href,'New letter', 'height=700, width=800'); return false;",
+            onclick: "window.open(this.href,'New letter', 'height=700, width=1000'); return false;",
             data: { turbo_prefetch: false } do %>
           <i class="bi bi-shuffle me-2"></i>
           ランダム表示


### PR DESCRIPTION
# 概要
- CSSのレスポンシブ対応をしたことによるお便りランダム表示ウィンドウの表示崩れの修正

## 内容
立ち上がる別ウィンドウの大きさを変更して対応