### PR TITLE
番組のアイキャッチ用画像を保存する際のバリデーションを追加

### DIFF
--- a/app/models/program.rb
+++ b/app/models/program.rb
@@ -12,6 +12,9 @@ class Program < ApplicationRecord
 
   has_one_attached :image
 
+  # 画像の拡張子とContent-Typeの制限
+  validate :acceptable_image
+
   def self.ransackable_associations(auth_object = nil)
     [ "letter", "letterbox", "user" ]
   end
@@ -37,5 +40,22 @@ class Program < ApplicationRecord
 
   def expiration_time
     (send_invitation_at + 3.days).strftime("%Y年%m月%d日 %H:%M")
+  end
+
+  private
+
+  def acceptable_image
+    return unless image.attached?
+
+    # ファイルサイズの制限（5MB以下）
+    unless image.byte_size <= 5.megabyte
+      errors.add(:image, 'のサイズは5MB以下にしてください')
+    end
+
+    # 許可する拡張子とContent-Type
+    acceptable_types = ['image/jpeg', 'image/png', 'image/gif', 'image/webp']
+    unless acceptable_types.include?(image.content_type)
+      errors.add(:image, 'はJPEG、PNG、GIF、WebP形式のみアップロード可能です')
+    end
   end
 end

--- a/app/views/programs/_form.html.erb
+++ b/app/views/programs/_form.html.erb
@@ -24,8 +24,21 @@
     </div>
 
     <div class="mb-4">
-      <%= form.label :image, class: "form-label" %>
-      <%= form.file_field :image, class:"form-control" %>
+      <%= form.label :image, "画像", class: "form-label" %>
+      <%= form.file_field :image,
+          class: "form-control",
+          accept: "image/jpeg,image/png,image/gif,image/webp",
+          data: {
+            controller: "file-validation",
+            file_validation_max_size_value: 5.megabytes,
+            file_validation_accepted_types_value: "image/jpeg,image/png,image/gif,image/webp"
+          } %>
+      <small class="form-text text-muted">
+        ※ JPEG、PNG、GIF、WebP形式（5MB以下）のみアップロード可能です
+      </small>
+      <div class="invalid-feedback">
+        ファイル形式が不正か、サイズが大きすぎます
+      </div>
     </div>
 
     <div class="text-end mt-4">

--- a/app/views/programs/edit.html.erb
+++ b/app/views/programs/edit.html.erb
@@ -26,7 +26,6 @@
       </div>
     <% end %>
     <div class="py-3">
-      <%= render 'shared/flash_message' %>
       <div class="glass-morphism p-4 mb-3">
         <div class="d-flex justify-content-between align-items-center mb-4">
           <h2 class="text-gradient h4 mb-0">


### PR DESCRIPTION
# 概要
番組のアイキャッチ用画像を保存する際のバリデーションを追加

## 内容
- 画像投稿用のフォームにjpeg,png,gif,webp以外は受け付けないように設定追加
- 画像の種類やサイズによるバリデーションをprogramに追加
