### PR TITLE
画像が正しく縮小されない問題の修正とviewの記述調整

### DIFF
--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -93,7 +93,6 @@ class ProgramsController < ApplicationController
           height: 480,
           size: :down,
           crop: :none,
-          linear: true
         )
 
         # WebPフォーマットに変換

--- a/app/views/programs/_form.html.erb
+++ b/app/views/programs/_form.html.erb
@@ -27,13 +27,9 @@
       <%= form.label :image, "画像", class: "form-label" %>
       <%= form.file_field :image,
           class: "form-control",
-          accept: "image/jpeg,image/png,image/gif,image/webp",
-          data: {
-            controller: "file-validation",
-            file_validation_max_size_value: 5.megabytes,
-            file_validation_accepted_types_value: "image/jpeg,image/png,image/gif,image/webp"
-          } %>
-      <small class="form-text text-muted">
+          accept: "image/jpeg,image/png,image/gif,image/webp"
+          %>
+      <small class="form-text text-white-50">
         ※ JPEG、PNG、GIF、WebP形式（5MB以下）のみアップロード可能です
       </small>
       <div class="invalid-feedback">


### PR DESCRIPTION
# 概要
- 画像が縮小される時に色が変わってしまう場合がある問題を修正
- viewの記述修正

## 内容
- 画像が縮小される時に光を抑えるというようなオプションが追加されていたのでその記述を削除
- viewでのリアルタイムバリデーションは現状追加しないことにしたので記述を削除