### PR TITLE
Programの画像に対するバリデーションをgemを使ったものに変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,9 @@ gem "thruster", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 gem "image_processing", "~> 1.2"
 
+# ActiveStorageのバリデーションを簡単に書けるgem
+gem 'active_storage_validations'
+
 # 画像保存用ストレージcloudinaryのgem
 gem "cloudinary"
 

--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem "thruster", require: false
 gem "image_processing", "~> 1.2"
 
 # ActiveStorageのバリデーションを簡単に書けるgem
-gem 'active_storage_validations'
+gem "active_storage_validations"
 
 # 画像保存用ストレージcloudinaryのgem
 gem "cloudinary"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,12 @@ GEM
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
+    active_storage_validations (2.0.2)
+      activejob (>= 6.1.4)
+      activemodel (>= 6.1.4)
+      activestorage (>= 6.1.4)
+      activesupport (>= 6.1.4)
+      marcel (>= 1.0.3)
     activejob (7.2.1)
       activesupport (= 7.2.1)
       globalid (>= 0.3.6)
@@ -402,6 +408,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  active_storage_validations
   bcrypt (= 3.1.18)
   bootsnap
   bootstrap5-kaminari-views

--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -29,7 +29,7 @@ class ProgramsController < ApplicationController
 
   def create
     @program = current_user.programs.build(program_params)
-    
+
     if params[:program][:image].present?
       process_and_transform_image(params[:program][:image])
     end
@@ -103,7 +103,7 @@ class ProgramsController < ApplicationController
         )
 
         # 新しい一時ファイルを作成して処理済み画像を書き込む
-        new_tempfile = Tempfile.new(['processed', '.webp'])
+        new_tempfile = Tempfile.new([ "processed", ".webp" ])
         new_tempfile.binmode
         new_tempfile.write(output_buffer)
         new_tempfile.rewind

--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -53,7 +53,6 @@ class ProgramsController < ApplicationController
     # まず属性の更新のみを行う
     @program.assign_attributes(program_params)
 
-    Rails.logger.debug "@program.valid? => #{@program.valid?}"
     if @program.valid?
       # 画像処理が必要な場合のみ実行
       if params[:program][:image].present?

--- a/app/models/program.rb
+++ b/app/models/program.rb
@@ -12,8 +12,10 @@ class Program < ApplicationRecord
 
   has_one_attached :image
 
-  # 画像の拡張子とContent-Typeの制限
-  validate :acceptable_image
+  # ファイルの種類とサイズのバリデーション（gem ActiveStorage Validationを使用）
+  ACCEPTED_CONTENT_TYPES = %w[image/jpeg image/png image/gif image/webp].freeze
+  validates :image, content_type: ACCEPTED_CONTENT_TYPES,
+                    size: { less_than_or_equal_to: 5.megabytes }
 
   def self.ransackable_associations(auth_object = nil)
     [ "letter", "letterbox", "user" ]
@@ -40,22 +42,5 @@ class Program < ApplicationRecord
 
   def expiration_time
     (send_invitation_at + 3.days).strftime("%Y年%m月%d日 %H:%M")
-  end
-
-  private
-
-  def acceptable_image
-    return unless image.attached?
-
-    # ファイルサイズの制限（5MB以下）
-    unless image.byte_size <= 5.megabyte
-      errors.add(:image, "のサイズは5MB以下にしてください")
-    end
-
-    # 許可する拡張子とContent-Type
-    acceptable_types = [ "image/jpeg", "image/png", "image/gif", "image/webp" ]
-    unless acceptable_types.include?(image.content_type)
-      errors.add(:image, "はJPEG、PNG、GIF、WebP形式のみアップロード可能です")
-    end
   end
 end

--- a/app/models/program.rb
+++ b/app/models/program.rb
@@ -49,13 +49,13 @@ class Program < ApplicationRecord
 
     # ファイルサイズの制限（5MB以下）
     unless image.byte_size <= 5.megabyte
-      errors.add(:image, 'のサイズは5MB以下にしてください')
+      errors.add(:image, "のサイズは5MB以下にしてください")
     end
 
     # 許可する拡張子とContent-Type
-    acceptable_types = ['image/jpeg', 'image/png', 'image/gif', 'image/webp']
+    acceptable_types = [ "image/jpeg", "image/png", "image/gif", "image/webp" ]
     unless acceptable_types.include?(image.content_type)
-      errors.add(:image, 'はJPEG、PNG、GIF、WebP形式のみアップロード可能です')
+      errors.add(:image, "はJPEG、PNG、GIF、WebP形式のみアップロード可能です")
     end
   end
 end

--- a/app/views/programs/_form.html.erb
+++ b/app/views/programs/_form.html.erb
@@ -32,9 +32,6 @@
       <small class="form-text text-white-50">
         ※ JPEG、PNG、GIF、WebP形式（5MB以下）のみアップロード可能です
       </small>
-      <div class="invalid-feedback">
-        ファイル形式が不正か、サイズが大きすぎます
-      </div>
     </div>
 
     <div class="text-end mt-4">

--- a/app/views/programs/_form.html.erb
+++ b/app/views/programs/_form.html.erb
@@ -27,7 +27,7 @@
       <%= form.label :image, "画像", class: "form-label" %>
       <%= form.file_field :image,
           class: "form-control",
-          accept: "image/jpeg,image/png,image/gif,image/webp"
+          accept: Program::ACCEPTED_CONTENT_TYPES.join(",")
           %>
       <small class="form-text text-white-50">
         ※ JPEG、PNG、GIF、WebP形式（5MB以下）のみアップロード可能です

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -50,7 +50,7 @@ ja:
               too_long: "番組の説明は最大255文字までです。"
             image:
               content_type_invalid: "はJPEG、PNG、GIF、WebP形式のみアップロード可能です"
-              file_size_out_of_range: "は5MB以下にしてください"
+              file_size_not_less_than_or_equal_to: "は %{max}以下にしてください (現在のサイズは %{file_size})"
         letterbox:
           attributes:
             title:

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -48,6 +48,9 @@ ja:
               too_long: "タイトルは最大100文字までです。"
             body:
               too_long: "番組の説明は最大255文字までです。"
+            image:
+              content_type_invalid: "はJPEG、PNG、GIF、WebP形式のみアップロード可能です"
+              file_size_out_of_range: "は5MB以下にしてください"
         letterbox:
           attributes:
             title:


### PR DESCRIPTION
# 概要
- 画像のバリデーションの記述を変更
- 画像の処理タイミング修正

## 内容
- ActiveStorage用のバリデーションをgemを用いたものに変更
- viewの画像用のフォーム部分も修正
- 画像の処理がバリデーションで許可されたファイルかどうか判断される前に行われてしまっていたのでバリデーションで許可されたことが確認されてから画像を処理するようにアクションの記述を変更

## その他
gem "active_storage_validations"でバリデーション書いた方が楽、スマート、みた時に直感的に分かりやすい！最高！