### PR TITLE
タイトルスクロールバグ修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,6 +81,8 @@ group :development, :test do
   gem "rubocop-rails-omakase", require: false
 
   gem "faker", "~> 3.5", ">= 3.5.1"
+  gem "rspec-rails", "~> 5.0"
+  gem "factory_bot_rails"
 end
 
 group :development do
@@ -94,4 +96,6 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver"
+
+  gem "webdrivers"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,12 +126,18 @@ GEM
       responders
       warden (~> 1.2.3)
     devise-i18n-views (0.3.7)
+    diff-lcs (1.5.1)
     dotenv (3.1.4)
     drb (2.2.1)
     ed25519 (1.3.0)
     erubi (1.13.0)
     et-orbi (1.2.11)
       tzinfo
+    factory_bot (6.5.0)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.4.4)
+      factory_bot (~> 6.5)
+      railties (>= 5.0.0)
     faker (3.5.1)
       i18n (>= 1.8.11, < 2)
     faraday (2.12.2)
@@ -313,6 +319,23 @@ GEM
       railties (>= 5.2)
     rexml (3.3.9)
     rouge (4.5.1)
+    rspec-core (3.13.2)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-rails (5.1.2)
+      actionpack (>= 5.2)
+      activesupport (>= 5.2)
+      railties (>= 5.2)
+      rspec-core (~> 3.10)
+      rspec-expectations (~> 3.10)
+      rspec-mocks (~> 3.10)
+      rspec-support (~> 3.10)
+    rspec-support (3.13.2)
     rubocop (1.68.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -396,6 +419,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webdrivers (5.2.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (~> 4.0)
     websocket (1.2.11)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
@@ -419,6 +446,7 @@ DEPENDENCIES
   debug
   devise (~> 4.9, >= 4.9.4)
   devise-i18n-views
+  factory_bot_rails
   faker (~> 3.5, >= 3.5.1)
   image_processing (~> 1.2)
   inline_svg
@@ -435,6 +463,7 @@ DEPENDENCIES
   ransack (= 4.2.1)
   redcarpet
   rouge
+  rspec-rails (~> 5.0)
   rubocop-rails-omakase
   selenium-webdriver
   solid_cable
@@ -445,6 +474,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
+  webdrivers
 
 BUNDLED WITH
    2.5.23

--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -1,6 +1,6 @@
-@import 'bootstrap/scss/bootstrap';
-@import 'bootstrap-icons/font/bootstrap-icons';
-@import 'rouge';
+@import "bootstrap/scss/bootstrap";
+@import "bootstrap-icons/font/bootstrap-icons";
+@import "rouge";
 
 // 変数定義
 $primary-gradient: linear-gradient(120deg, #7aa2f7, #bb9af7);
@@ -17,7 +17,9 @@ body {
 
 // ヘッダー
 header {
-  &.random_letters-random, &.random_letters-reset, &.random_letters-show {
+  &.random_letters-random,
+  &.random_letters-reset,
+  &.random_letters-show {
     display: none;
   }
 }
@@ -84,15 +86,15 @@ header {
 }
 
 .btn-outline-primary {
-  border: 1px solid rgba(65, 132, 228, 0.3);  // 青色を基調とした境界線
-  color: #4184e4;  // ベースの青色
+  border: 1px solid rgba(65, 132, 228, 0.3); // 青色を基調とした境界線
+  color: #4184e4; // ベースの青色
   background: transparent;
   transition: $transition-base;
 
   &:hover {
-    background: rgba(65, 132, 228, 0.1);  // ホバー時の薄い青色の背景
-    border-color: rgba(65, 132, 228, 0.5);  // ホバー時の濃い目の境界線
-    color: #89b4f7;  // ホバー時の明るい青色
+    background: rgba(65, 132, 228, 0.1); // ホバー時の薄い青色の背景
+    border-color: rgba(65, 132, 228, 0.5); // ホバー時の濃い目の境界線
+    color: #89b4f7; // ホバー時の明るい青色
   }
 }
 
@@ -114,8 +116,7 @@ header {
   background: rgba(26, 27, 38, 0.7);
   backdrop-filter: blur(10px);
   border-radius: 16px;
-  box-shadow:
-    0 4px 30px rgba(192, 202, 245, 0.1),
+  box-shadow: 0 4px 30px rgba(192, 202, 245, 0.1),
     inset 0 0 0 1px rgba(192, 202, 245, 0.1);
   margin-bottom: 2rem;
 }
@@ -124,8 +125,7 @@ header {
   background: rgba(25, 26, 36, 0.986);
   backdrop-filter: blur(10px);
   border-radius: 16px;
-  box-shadow:
-    0 4px 30px rgba(192, 202, 245, 0.1),
+  box-shadow: 0 4px 30px rgba(192, 202, 245, 0.1),
     inset 0 0 0 1px rgba(192, 202, 245, 0.1);
 }
 
@@ -143,13 +143,13 @@ a {
   .nav-hover {
     position: relative;
     transition: transform 0.2s ease;
-    
+
     &:hover {
       transform: translateY(-2px);
     }
-    
+
     &::after {
-      content: '';
+      content: "";
       position: absolute;
       bottom: -2px;
       left: 0;
@@ -160,7 +160,7 @@ a {
       transition: transform 0.2s ease;
       transform-origin: right;
     }
-    
+
     &:hover::after {
       transform: scaleX(1);
       transform-origin: left;
@@ -182,7 +182,7 @@ a {
 // レターカード
 .letter-card {
   transition: $transition-base;
-  
+
   .program-icon {
     width: 40px;
     height: 40px;
@@ -193,15 +193,15 @@ a {
     border-radius: 12px;
     color: #7aa2f7;
   }
-  
+
   .program-info small {
     font-size: 0.75rem;
     opacity: 0.8;
   }
-  
+
   .card-title {
     line-height: 1.5;
-    
+
     a {
       display: -webkit-box;
       -webkit-line-clamp: 2;
@@ -209,18 +209,18 @@ a {
       overflow: hidden;
     }
   }
-  
+
   .transition-icon {
     transition: transform 0.3s ease;
   }
-  
+
   &:hover .transition-icon {
     transform: translateX(5px);
   }
-  
+
   .btn {
     transition: $transition-base;
-    
+
     &:hover {
       transform: translateY(-2px);
       box-shadow: 0 4px 15px rgba(122, 162, 247, 0.3);
@@ -260,7 +260,7 @@ a {
 #programs .col-md-6,
 #letterboxes .col-md-6 {
   animation: fadeIn 0.6s ease backwards;
-  
+
   @for $i from 1 through 12 {
     &:nth-child(#{$i}) {
       animation-delay: #{$i * 0.1}s;
@@ -270,10 +270,16 @@ a {
 
 // レスポンシブ設定
 @media (max-width: 992px) {
-  .display-5 { font-size: 2rem; }
-  .display-6 { font-size: 1.5rem; }
-  .glass-morphism { padding: 1.5rem !important; }
-  
+  .display-5 {
+    font-size: 2rem;
+  }
+  .display-6 {
+    font-size: 1.5rem;
+  }
+  .glass-morphism {
+    padding: 1.5rem !important;
+  }
+
   .d-flex {
     flex-direction: column;
     gap: 1rem;
@@ -296,14 +302,14 @@ a {
 .program-title-link.nav-hover {
   position: relative;
   transition: transform 0.2s ease;
-  display: inline-block;  // インラインブロック要素として表示
-  
+  display: inline-block; // インラインブロック要素として表示
+
   &:hover {
     transform: translateY(-2px);
   }
-  
+
   &::after {
-    content: '';
+    content: "";
     position: absolute;
     bottom: -2px;
     left: 0;
@@ -314,7 +320,7 @@ a {
     transition: transform 0.2s ease;
     transform-origin: right;
   }
-  
+
   &:hover::after {
     transform: scaleX(1);
     transform-origin: left;
@@ -332,15 +338,15 @@ a {
   text-decoration: none;
   transition: transform 0.2s ease;
   display: inline-block;
-  
+
   &.nav-hover {
     &:hover {
       transform: translateY(-2px);
-      color: #bb9af7;  // ホバー時の文字色
+      color: #bb9af7; // ホバー時の文字色
     }
-    
+
     &::after {
-      content: '';
+      content: "";
       position: absolute;
       bottom: -2px;
       left: 0;
@@ -351,13 +357,13 @@ a {
       transition: transform 0.2s ease;
       transform-origin: right;
     }
-    
+
     &:hover::after {
       transform: scaleX(1);
       transform-origin: left;
     }
   }
-  
+
   // グラデーションテキストのホバー効果
   &:hover {
     background: linear-gradient(120deg, #bb9af7, #7aa2f7);
@@ -385,7 +391,6 @@ a {
   }
 }
 
-
 // プログラムリスト用のスタイル
 .row.g-4 {
   margin-top: 1.5rem;
@@ -397,7 +402,7 @@ a {
     .d-flex {
       flex-direction: column;
       gap: 1rem;
-      
+
       .btn {
         width: 100%;
       }
@@ -406,7 +411,7 @@ a {
 
   .search-form {
     padding: 1rem;
-    
+
     .col-md-5,
     .col-md-2 {
       width: 100%;
@@ -430,12 +435,11 @@ a {
   }
 }
 
-
 // レスポンシブ対応
 @media (max-width: 992px) {
   .pagination {
     gap: 0.4rem;
-    
+
     .page-item {
       .page-link {
         padding: 0.6rem 0.8rem;
@@ -443,8 +447,9 @@ a {
         min-height: 2.4rem;
         font-size: 0.9rem;
       }
-      
-      &.prev, &.next {
+
+      &.prev,
+      &.next {
         .page-link {
           padding: 0.6rem 1rem;
         }
@@ -506,18 +511,15 @@ a {
 .share-link {
   // 既存のスタイルに追加
   &::before {
-    content: '';
+    content: "";
     position: absolute;
     inset: 0;
     border-radius: 50px;
     padding: 2px;
     background: linear-gradient(120deg, #7aa2f7, #bb9af7);
-    -webkit-mask: 
-      linear-gradient(#fff 0 0) content-box, 
+    -webkit-mask: linear-gradient(#fff 0 0) content-box,
       linear-gradient(#fff 0 0);
-    mask: 
-      linear-gradient(#fff 0 0) content-box, 
-      linear-gradient(#fff 0 0);
+    mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
     -webkit-mask-composite: xor;
     mask-composite: exclude;
     opacity: 0;
@@ -561,7 +563,6 @@ a {
   }
 }
 
-
 // アニメーション
 .pulse-animation {
   animation: pulse 2s infinite;
@@ -573,15 +574,27 @@ a {
 }
 
 @keyframes pulse {
-  0% { opacity: 1; }
-  50% { opacity: 0.3; }
-  100% { opacity: 1; }
+  0% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.3;
+  }
+  100% {
+    opacity: 1;
+  }
 }
 
 @keyframes wave {
-  0% { transform: scale(1); }
-  50% { transform: scale(1.2); }
-  100% { transform: scale(1); }
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.2);
+  }
+  100% {
+    transform: scale(1);
+  }
 }
 
 // レスポンシブ対応
@@ -658,7 +671,7 @@ a {
 .pagination {
   gap: 0.6rem;
   margin: 2.5rem 0;
-  
+
   .page-item {
     .page-link {
       background: rgba(26, 27, 38, 0.7);
@@ -674,7 +687,7 @@ a {
       justify-content: center;
       transition: all 0.3s ease;
       margin: 0;
-      
+
       &:hover {
         background: rgba(122, 162, 247, 0.15);
         border-color: #7aa2f7;
@@ -698,7 +711,6 @@ a {
       color: rgba(192, 202, 245, 0.5);
       cursor: not-allowed;
     }
-
 
     // アクティブなページ
     &.active .page-link {
@@ -727,11 +739,12 @@ a {
     }
 
     // 前へ/次へボタン
-    &.prev, &.next {
+    &.prev,
+    &.next {
       .page-link {
         padding: 0.7rem 1.2rem;
         min-width: 3.2rem;
-        
+
         span {
           position: relative;
           top: -1px;
@@ -772,19 +785,7 @@ a {
 }
 
 .title-scroll {
-  animation: scrollText 11s infinite;
-}
-
-@keyframes scrollText {
-  0%, 20% {
-    transform: translateX(0);
-  }
-  65%, 90% {
-    transform: translateX(calc(-100% + 18em));
-  }
-  100% {
-    transform: translateX(0);
-  }
+  animation: none; // 初期状態ではアニメーションを無効化
 }
 
 @media (max-width: 992px) {
@@ -801,10 +802,12 @@ a {
   }
 
   @keyframes scrollText {
-    0%, 20% {
+    0%,
+    20% {
       transform: translateX(0);
     }
-    65%, 90% {
+    65%,
+    90% {
       transform: translateX(calc(-100% + 10em));
     }
     100% {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -42,9 +42,28 @@
       }
 
       document.querySelectorAll('.scroll').forEach(elem => {
-        // const span = document.getElementById('title-span');
         const span = elem.querySelector('span');
         if (span.scrollWidth > elem.clientWidth) {
+          // スクロールが必要な場合のみアニメーションを適用
+          const scrollDistance = span.scrollWidth - elem.clientWidth;
+          
+          // CSSアニメーションを動的に生成
+          const styleSheet = document.styleSheets[0];
+          const animationName = `scrollText-${Math.random().toString(36).substr(2, 9)}`; // ユニークな名前を生成
+          
+          const keyframes = `
+            @keyframes ${animationName} {
+              0%, 20% { transform: translateX(0); }
+              65%, 90% { transform: translateX(-${scrollDistance}px); }
+              100% { transform: translateX(0); }
+            }
+          `;
+          
+          // スタイルシートにキーフレームを追加
+          styleSheet.insertRule(keyframes, styleSheet.cssRules.length);
+          
+          // アニメーションを要素に適用
+          span.style.animation = `${animationName} ${Math.min(20, Math.max(11, scrollDistance / 50))}s infinite`;
           span.classList.add('title-scroll');
         }
       });

--- a/app/views/letterboxes/index.html.erb
+++ b/app/views/letterboxes/index.html.erb
@@ -8,6 +8,11 @@
         <i class="bi bi-envelope me-3"></i>
         お便り箱一覧
       </h1>
+      <%= link_to new_program_letterbox_path(@program), 
+          class: "btn btn-primary rounded-pill px-4 hover-lift" do %>
+        <i class="bi bi-plus-lg me-2"></i>
+        お便り箱新規作成
+      <% end %>
     </div>
 
     <div class="search-form-container">

--- a/app/views/programs/show.html.erb
+++ b/app/views/programs/show.html.erb
@@ -3,7 +3,6 @@
 <div class="container py-5">
   <%= render 'shared/flash_message' %>
   <div class="glass-morphism p-5 mb-5">
-    
     <div class="d-flex justify-content-between align-items-start mb-4">
       <div class="w-100">
         <h1 class="text-gradient display-5 fw-bold mb-4">


### PR DESCRIPTION
# 概要
- closes #171 
- お便り箱管理ページに新規作成ボタン追加
- test用のgem追加

## 内容
- タイトルスクロールのバグを修正するために、タイトルの長さがそれを囲んでいる親要素より長い場合　（子要素）- （親要素）の長さ文だけスクロールするようにJSで記述して都度stylesheetに追加する記述を追加
- お便り箱管理ページに新規作成ボタンが無くて不便そうだったので追加
- ついでに今後使いそうなテスト用のgemを追加