### PR TITLE
認可機能をpunditに換装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,8 @@ gem "devise-i18n-views"
 gem "redcarpet"
 gem "rouge"
 
+gem "pundit"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,6 +265,8 @@ GEM
     public_suffix (6.0.1)
     puma (6.4.3)
       nio4r (~> 2.0)
+    pundit (2.5.0)
+      activesupport (>= 3.0.0)
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.1.8)
@@ -464,6 +466,7 @@ DEPENDENCIES
   pg (~> 1.1)
   propshaft
   puma (>= 5.0)
+  pundit
   rails (= 7.2.1)
   ransack (= 4.2.1)
   redcarpet

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,10 @@ class ApplicationController < ActionController::Base
   # allow_browser versions: :modern
   include ProgramsHelper
   include UsersHelper
+  include Pundit::Authorization
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+  def user_not_authorized
+    flash[:alert] = "このアクションは許可されていません"
+    redirect_to(request.referrer || root_path)
+  end
 end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,26 +1,32 @@
 class InvitationsController < ApplicationController
   before_action :set_program, only: %i[ show new create edit update]
   before_action :authenticate_user!, only: %i[ show new create edit update ]
-  before_action :authorized_user, only: %i[ show new create ]
   before_action :email_registered_user, only: %i[ show new create edit update ]
   before_action :valid_user, only: %i[ edit update ]
   before_action :check_expiration, only: %i[ update ]
 
   def show
+    authorize @program, policy_class: InvitationPolicy
     @expiration_time = @program.expiration_time
   end
 
-  def new; end
+  def new
+    authorize @program, policy_class: InvitationPolicy
+  end
 
   def create
+    authorize @program, policy_class: InvitationPolicy
     @program.create_invitation_digest
     flash[:notice]= "招待リンクを作成しました"
     redirect_to program_invitation_path(@program, @program.invitation_token)
   end
 
-  def edit; end
+  def edit
+    authorize @program, policy_class: InvitationPolicy
+  end
 
   def update
+    authorize @program, policy_class: InvitationPolicy
     participation = UserParticipation.new(user: current_user, program: @program)
     if participation.save
       flash[:notice]= "#{@program.title}の制作に参加しました"
@@ -42,12 +48,6 @@ class InvitationsController < ApplicationController
     def valid_user
       unless @program && @program.authenticated?(params[:id])
         redirect_to root_url
-      end
-    end
-
-    def authorized_user
-      unless producer?(current_user, @program) || current_user.admin?
-        redirect_to(root_url, status: :see_other)
       end
     end
 end

--- a/app/controllers/letter_status_controller.rb
+++ b/app/controllers/letter_status_controller.rb
@@ -4,10 +4,12 @@ class LetterStatusController < ApplicationController
   before_action :email_registered_user, only: %i[ read unread ]
 
   def read
+    authorize @letter.program, policy_class: LetterStatusPolicy
     @letter.update(is_read: true)
   end
 
   def unread
+    authorize @letter.program, policy_class: LetterStatusPolicy
     @letter.update(is_read: false)
   end
 

--- a/app/controllers/letterboxes_controller.rb
+++ b/app/controllers/letterboxes_controller.rb
@@ -3,21 +3,25 @@ class LetterboxesController < ApplicationController
   before_action :set_program, only: %i[ index new create edit update destroy ]
   before_action :authenticate_user!, only: %i[ index new create edit update destroy ]
   before_action :email_registered_user, only: %i[ new create edit update destroy ]
-  before_action :authorized_user, only: %i[ new create edit update destroy ]
 
   def index
+    authorize @program, policy_class: LetterboxPolicy
     @q = @program.letterboxes.ransack(params[:q])
     @result = @q.result(distinct: true)
     @letterboxes = @result.order(created_at: :desc).page(params[:page]).per(10)
   end
 
   def new
+    authorize @program, policy_class: LetterboxPolicy
     @letterbox = Letterbox.new
   end
 
-  def edit; end
+  def edit
+    authorize @program, policy_class: LetterboxPolicy
+  end
 
   def create
+    authorize @program, policy_class: LetterboxPolicy
     @letterbox = @program.letterboxes.build(letterbox_params)
     if @letterbox.save
       flash[:notice]= "お便り箱を作成しました"
@@ -29,6 +33,7 @@ class LetterboxesController < ApplicationController
   end
 
   def update
+    authorize @program, policy_class: LetterboxPolicy
     if @letterbox.update(letterbox_params)
       flash[:notice]= "お便り箱を編集しました"
       redirect_to @program
@@ -39,6 +44,7 @@ class LetterboxesController < ApplicationController
   end
 
   def destroy
+    authorize @program, policy_class: LetterboxPolicy
     @letterbox.destroy!
     flash[:notice]= "お便り箱を削除しました"
     redirect_to @program, status: :see_other
@@ -52,11 +58,5 @@ class LetterboxesController < ApplicationController
 
     def letterbox_params
       params.require(:letterbox).permit(:title, :body)
-    end
-
-    def authorized_user
-      unless producer?(current_user, @program) || current_user.admin?
-        redirect_to(root_url, status: :see_other)
-      end
     end
 end

--- a/app/controllers/object_publish_controller.rb
+++ b/app/controllers/object_publish_controller.rb
@@ -1,11 +1,12 @@
 class ObjectPublishController < ApplicationController
   before_action :set_program, only: %i[ switch_publish ]
-  before_action :authorized_user, only: %i[ switch_publish ]
   before_action :set_object, only: %i[ switch_publish ]
   before_action :authenticate_user!, only: %i[ switch_publish ]
   before_action :email_registered_user, only: %i[ switch_publish ]
 
   def switch_publish
+    program = @program || @object.program
+    authorize program, policy_class: ObjectPublishPolicy
     @object.update(publish: !@object.publish)
   end
 
@@ -14,11 +15,5 @@ class ObjectPublishController < ApplicationController
     def set_object
       @model = params[:model_name].constantize
       @object = @model.find(params[:id])
-    end
-
-    def authorized_user
-      unless producer?(current_user, @program) || current_user.admin?
-        redirect_to(root_url, status: :see_other)
-      end
     end
 end

--- a/app/controllers/random_letters_controller.rb
+++ b/app/controllers/random_letters_controller.rb
@@ -1,14 +1,15 @@
 class RandomLettersController < ApplicationController
   include LettersHelper
   before_action :set_program, only: %i[ show random reset ]
-  before_action :authorized_user, only: %i[ show random reset ]
   before_action :email_registered_user, only: %i[ show random reset ]
 
   def show
+    authorize @program, policy_class: RandomLetterPolicy
     @letters = fetch_letters(params[:q])
   end
 
   def random
+    authorize @program, policy_class: RandomLetterPolicy
     @letters = fetch_letters(params[:q])
     return render "letters/nothing" unless @letters
     @letter = letter_sampling(@letters)
@@ -16,6 +17,7 @@ class RandomLettersController < ApplicationController
   end
 
   def reset
+    authorize @program, policy_class: RandomLetterPolicy
     @letters = fetch_letters(params[:q])
     @letters.reset_is_read
     redirect_to program_random_letters_path(q: permitted_q_params)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,18 +1,20 @@
 class UsersController < ApplicationController
   before_action :set_user, only: %i[ show destroy ]
   before_action :authenticate_user!, only: %i[ index destroy ]
-  before_action :admin_user, only: %i[ index destroy ]
 
   def index
     @users = User.all.page(params[:page]).per(10)
+    authorize @users
   end
 
   def show
+    authorize @user
     @programs = @user.joined_programs.order(created_at: :desc).page(params[:page]).per(6)
     @letters = @user.letters.includes(:program).page(params[:page]).per(10)
   end
 
   def destroy
+    authorize @user
     programs = @user.programs
     @user.destroy!
     flash[:success] = "ユーザーを削除しました"
@@ -27,14 +29,5 @@ class UsersController < ApplicationController
 
     def user_params
       params.require(:user).permit(:name, :password, :password_confirmation)
-    end
-
-    def correct_user
-      @user = User.find(params[:id])
-      redirect_to(root_url, status: :see_other) unless current_user?(@user) || current_user&.admin?
-    end
-
-    def admin_user
-      redirect_to root_url, status: :see_other unless current_user&.admin?
     end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+class ApplicationPolicy
+  attr_reader :user, :record, :params
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    false
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  private
+
+  def program_producer?(target_record = nil)
+    return false unless user
+    record_to_check = target_record || record
+    program_id = record_to_check.try(:program_id) || record_to_check.id
+    UserParticipation.exists?(user_id: user.id, program_id: program_id)
+  end
+
+  class Scope
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      raise NoMethodError, "You must define #resolve in #{self.class}"
+    end
+
+    private
+
+    attr_reader :user, :scope
+  end
+end

--- a/app/policies/invitation_policy.rb
+++ b/app/policies/invitation_policy.rb
@@ -1,0 +1,13 @@
+class InvitationPolicy < ApplicationPolicy
+  def show?
+    user.admin? || program_producer?
+  end
+
+  def create?
+    show?
+  end
+
+  def update?
+    true
+  end
+end

--- a/app/policies/letter_policy.rb
+++ b/app/policies/letter_policy.rb
@@ -1,0 +1,17 @@
+class LetterPolicy < ApplicationPolicy
+  def index?
+    user.admin? || program_producer?
+  end
+
+  def show?
+    user.admin? || program_producer? || owner?
+  end
+
+  def create?
+    true
+  end
+
+  def destroy?
+    user.admin? || program_producer?(record.program) || owner?
+  end
+end

--- a/app/policies/letter_status_policy.rb
+++ b/app/policies/letter_status_policy.rb
@@ -1,0 +1,9 @@
+class LetterStatusPolicy < ApplicationPolicy
+  def read?
+    user.admin? || program_producer?
+  end
+
+  def unread?
+    read?
+  end
+end

--- a/app/policies/letterbox_policy.rb
+++ b/app/policies/letterbox_policy.rb
@@ -1,0 +1,17 @@
+class LetterboxPolicy < ApplicationPolicy
+  def index?
+    user.admin? || program_producer?
+  end
+
+  def create?
+    user.admin? || program_producer?
+  end
+
+  def update?
+    create?
+  end
+
+  def destroy?
+    create?
+  end
+end

--- a/app/policies/object_publish_policy.rb
+++ b/app/policies/object_publish_policy.rb
@@ -1,0 +1,5 @@
+class ObjectPublishPolicy < ApplicationPolicy
+  def switch_publish?
+    user.admin? || program_producer?
+  end
+end

--- a/app/policies/program_policy.rb
+++ b/app/policies/program_policy.rb
@@ -1,0 +1,25 @@
+class ProgramPolicy < ApplicationPolicy
+  def index?
+    true
+  end
+
+  def show?
+    true
+  end
+
+  def create?
+    true
+  end
+
+  def new?
+    true
+  end
+
+  def update?
+    user.admin? || program_producer?
+  end
+
+  def destroy?
+    update?
+  end
+end

--- a/app/policies/random_letter_policy.rb
+++ b/app/policies/random_letter_policy.rb
@@ -1,0 +1,13 @@
+class RandomLetterPolicy < ApplicationPolicy
+  def show?
+    user.admin? || program_producer?
+  end
+
+  def random?
+    show?
+  end
+
+  def reset?
+    show?
+  end
+end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,0 +1,13 @@
+class UserPolicy < ApplicationPolicy
+  def index?
+    user.admin?
+  end
+
+  def show?
+    true
+  end
+
+  def destroy?
+    user.admin?
+  end
+end

--- a/spec/system/programs_spec.rb
+++ b/spec/system/programs_spec.rb
@@ -61,6 +61,7 @@ RSpec.describe 'Programs', type: :system do
         it '3日以内の場合、リンクが有効であること', js: true do
           program.update(send_invitation_at: 2.days.ago)
           visit edit_program_invitation_path(program, program.invitation_token)
+          expect(page).to have_button '参加する'
           click_button '参加する'
           expect(page).to have_content "#{program.title}の制作に参加しました"
         end
@@ -68,6 +69,7 @@ RSpec.describe 'Programs', type: :system do
         it '3日以上経過した場合、リンクが無効になること', js: true do
           program.update(send_invitation_at: 4.days.ago)
           visit edit_program_invitation_path(program, program.invitation_token)
+          expect(page).to have_button '参加する'
           click_button '参加する'
           expect(page).to have_content '招待リンクが期限切れです'
         end


### PR DESCRIPTION
# 概要
gem pudit を用いたものに認可機能を換装

## 内容
コントローラーをスマートにするために認可機能を換装
現在の認可機能は以下

### UsersController
1. `set_user`
   - 対象アクション: `show`, `destroy`
   - 機能: ユーザー情報の取得

2. `authenticate_user!`
   - 対象アクション: `index`, `destroy`
   - 機能: ログインユーザーのみアクセス可能

3. `admin_user`
   - 対象アクション: `index`, `destroy`
   - 機能: 管理者のみアクセス可能

### ProgramsController
1. `set_program`
   - 対象アクション: `show`, `edit`, `update`, `destroy`
   - 機能: 番組情報の取得

2. `authenticate_user!`
   - 対象アクション: `new`, `create`, `edit`, `update`, `destroy`
   - 機能: ログインユーザーのみアクセス可能

3. `email_registered_user`
   - 対象アクション: `new`, `create`, `edit`, `update`, `destroy`
   - 機能: メール登録済みユーザーのみアクセス可能

4. `authorized_user`
   - 対象アクション: `edit`, `update`, `destroy`
   - 機能: 番組制作者または管理者のみアクセス可能

### LetterboxesController
1. `set_letterbox`
   - 対象アクション: `edit`, `update`, `destroy`
   - 機能: お便り箱情報の取得

2. `set_program`
   - 対象アクション: `index`, `new`, `create`, `edit`, `update`, `destroy`
   - 機能: 番組情報の取得

3. `authenticate_user!`
   - 対象アクション: `index`, `new`, `create`, `edit`, `update`, `destroy`
   - 機能: ログインユーザーのみアクセス可能

4. `email_registered_user`
   - 対象アクション: `new`, `create`, `edit`, `update`, `destroy`
   - 機能: メール登録済みユーザーのみアクセス可能

5. `authorized_user`
   - 対象アクション: `new`, `create`, `edit`, `update`, `destroy`
   - 機能: 番組制作者または管理者のみアクセス可能

### LettersController
1. `set_letter`
   - 対象アクション: `show`, `destroy`
   - 機能: お便り情報の取得

2. `set_program`
   - 対象アクション: `index`, `show`, `new`, `create`
   - 機能: 番組情報の取得

3. `authenticate_user!`
   - 対象アクション: `index`, `show`, `destroy`
   - 機能: ログインユーザーのみアクセス可能

4. `email_registered_user`
   - 対象アクション: `index`
   - 機能: メール登録済みユーザーのみアクセス可能

5. `editable_user`
   - 対象アクション: `destroy`
   - 機能: お便り作成者または管理者のみアクセス可能

6. `authorized_user`
   - 対象アクション: `show`
   - 機能: 番組制作者、管理者、またはお便り作成者のみアクセス可能

### InvitationsController
1. `set_program`
   - 対象アクション: `show`, `new`, `create`, `edit`, `update`
   - 機能: 番組情報の取得

2. `authenticate_user!`
   - 対象アクション: `show`, `new`, `create`, `edit`, `update`
   - 機能: ログインユーザーのみアクセス可能

3. `authorized_user`
   - 対象アクション: `show`, `new`, `create`
   - 機能: 番組制作者または管理者のみアクセス可能

4. `email_registered_user`
   - 対象アクション: `show`, `new`, `create`, `edit`, `update`
   - 機能: メール登録済みユーザーのみアクセス可能

5. `valid_user`
   - 対象アクション: `edit`, `update`
   - 機能: 招待リンクの有効性確認

6. `check_expiration`
   - 対象アクション: `update`
   - 機能: 招待リンクの期限切れ確認

### LetterStatusController
1. `set_letter`
   - 対象アクション: `read`, `unread`
   - 機能: お便り情報の取得

2. `authenticate_user!`
   - 対象アクション: `read`, `unread`
   - 機能: ログインユーザーのみアクセス可能

3. `email_registered_user`
   - 対象アクション: `read`, `unread`
   - 機能: メール登録済みユーザーのみアクセス可能

### ObjectPublishController
1. `set_program`
   - 対象アクション: `switch_publish`
   - 機能: 番組情報の取得

2. `authorized_user`
   - 対象アクション: `switch_publish`
   - 機能: 番組制作者または管理者のみアクセス可能

3. `set_object`
   - 対象アクション: `switch_publish`
   - 機能: 公開対象オブジェクトの取得

4. `authenticate_user!`
   - 対象アクション: `switch_publish`
   - 機能: ログインユーザーのみアクセス可能

5. `email_registered_user`
   - 対象アクション: `switch_publish`
   - 機能: メール登録済みユーザーのみアクセス可能

### RandomLettersController
1. `set_program`
   - 対象アクション: `show`, `random`, `reset`
   - 機能: 番組情報の取得

2. `authorized_user`
   - 対象アクション: `show`, `random`, `reset`
   - 機能: 番組制作者、管理者、またはお便り作成者のみアクセス可能

3. `email_registered_user`
   - 対象アクション: `show`, `random`, `reset`
   - 機能: メール登録済みユーザーのみアクセス可能