### PR TITLE
番組の画像が設定されていた場合そちらに切り替える動的OGPの設定追加

### DIFF
--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -17,6 +17,9 @@ class ProgramsController < ApplicationController
     @letterboxes = @program.letterboxes.published
     @star_rankings = @program.cached_star_rankings
     logger.swim @star_rankings
+    if @program.image.attached?
+      set_meta_tags(og: { title: @program.title, image: url_for(@program.image.variant(format: :jpg)) }, twitter: { image: url_for(@program.image.variant(format: :jpg)) })
+    end
   end
 
   def new


### PR DESCRIPTION
# 概要
- 番組の画像が設定されていた場合そちらに切り替える動的OGPの設定追加

## 内容
- programs_controllerのshowアクションに直接設定書いた。WebpのOGP映らない可能性あるらしくてとりあえずバリアントでjpeg生成してるけど、program imageの保存後のprogram showの初回アクセス時に一緒に生成してるっぽいからワンチャン重いかも。後々処理見直す必要あるかも